### PR TITLE
Fix Prisma unique filters for post operations and Stripe webhook

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -37,9 +37,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Missing post ID" }, { status: 400 });
     }
     const existing = await prisma.post.findUnique({
-      where: { id: postId, userId: session.user.id }
+      where: { id: postId }
     });
-    if (!existing) {
+    if (!existing || existing.userId !== session.user.id) {
       return NextResponse.json({ error: "Post not found" }, { status: 404 });
     }
 

--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -19,8 +19,16 @@ export async function PUT(request: Request, { params }: { params: { id: string }
   const { introduction, body: contentBody, conclusion, keywords, seo, tone, audience, length } = body;
 
   try {
+    const existing = await prisma.post.findUnique({
+      where: { id: params.id }
+    });
+
+    if (!existing || existing.userId !== session.user.id) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
     const updated = await prisma.post.update({
-      where: { id: params.id, userId: session.user.id },
+      where: { id: params.id },
       data: {
         introduction,
         body: contentBody,
@@ -47,9 +55,14 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
   }
 
   try {
-    await prisma.post.delete({
+    const deleted = await prisma.post.deleteMany({
       where: { id: params.id, userId: session.user.id }
     });
+
+    if (deleted.count === 0) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error(error);

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request) {
           }
         });
         await prisma.user.updateMany({
-          where: { subscription: { stripeSubscriptionId: subscription.id } },
+          where: { subscription: { is: { stripeSubscriptionId: subscription.id } } },
           data: { role: "FREE" }
         });
         break;

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -15,10 +15,10 @@ export default async function PostPage({ params }: PostPageProps) {
   }
 
   const post = await prisma.post.findUnique({
-    where: { id: params.id, userId: session.user.id }
+    where: { id: params.id }
   });
 
-  if (!post) {
+  if (!post || post.userId !== session.user.id) {
     notFound();
   }
 


### PR DESCRIPTION
## Summary
- enforce ownership checks after fetching posts by unique id in regeneration, edit, and page handlers
- guard delete requests with deleteMany and 404 when the post is missing or belongs to another user
- correct the Stripe webhook relation filter to use the `is` operator when downgrading users

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dcffcd898832daca758c3a6c4f26b)